### PR TITLE
Smaller docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM alpine
-RUN apk add --update git cmake make gcc g++ libc-dev boost-dev
-RUN git clone --recursive https://github.com/kost/nheqminer.git
-WORKDIR /nheqminer/nheqminer
-RUN mkdir build
-WORKDIR /nheqminer/nheqminer/build
-RUN cmake -DSTATIC_BUILD=1 -DXENON=2 -DMARCH="-m64" ..
-RUN make
-RUN apk del git cmake gcc g++ libc-dev boost-dev
+
+RUN apk add --no-cache --virtual=build-dependencies git cmake make gcc g++ libc-dev boost-dev && \
+    git clone --recursive https://github.com/kost/nheqminer.git && \
+    cd /nheqminer/nheqminer && \
+    mkdir build && \
+    cd /nheqminer/nheqminer/build && \
+    cmake -DSTATIC_BUILD=1 -DXENON=2 -DMARCH="-m64" .. && \
+    make && \
+    apk del --purge build-dependencies
+    
 ENTRYPOINT ["/nheqminer/nheqminer/build/nheqminer"]


### PR DESCRIPTION
The previous Dockerfile resulted in a huge image because the dependencies where deleted in a separate RUN command